### PR TITLE
Update apache jmeter url

### DIFF
--- a/jenkins/jobs/dsl/java_reference_application_jobs.groovy
+++ b/jenkins/jobs/dsl/java_reference_application_jobs.groovy
@@ -380,7 +380,7 @@ performanceTestJob.with {
             |if [ -e ../apache-jmeter-2.13.tgz ]; then
             |	cp ../apache-jmeter-2.13.tgz $JMETER_TESTDIR
             |else
-            |	wget http://www.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz
+            |	wget http://archive.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz
             |    cp apache-jmeter-2.13.tgz ../
             |    mv apache-jmeter-2.13.tgz $JMETER_TESTDIR
             |fi


### PR DESCRIPTION
Fixing the issue with the performance test job... reconfigure the wget in the jenkins job to this url instead:
http://archive.apache.org/dist/jmeter/binaries/apache-jmeter-2.13.tgz